### PR TITLE
display n scheduled backups on calendar instead of 32

### DIFF
--- a/app/controllers/machine.js
+++ b/app/controllers/machine.js
@@ -28,7 +28,7 @@ router.get('/:name',(req, res, next) => {
   config = system.getConfig();
   db = models.getDatabase();
 
-  getBackupEvents(machine, 5)
+  getBackupEvents(machine, machine.buckets.length)
   .then(backupEvents => {
     const machineInfo = {
       title: `${machine.name} :: Alcove Backup System`,
@@ -60,7 +60,7 @@ module.exports = app => {
  *   An object containing the calendar object with the backup events
  *   and a list of backup events
  */
-function getBackupEvents(machine, CALENDAR_ROWS = 5)
+function getBackupEvents(machine, CALENDAR_ROWS = 5) 
 {
   let today = new Date();
 


### PR DESCRIPTION
this allows for any number of scheduled backups, resolving the issue (#107 )